### PR TITLE
added forgotten mapping for SCS Trucksims

### DIFF
--- a/simapi/simmapper.c
+++ b/simapi/simmapper.c
@@ -726,6 +726,7 @@ int simdatamap(SimData* simdata, SimMap* simmap, SimMap* simmap2, SimulatorAPI s
 
         case SIMULATORAPI_SCSTRUCKSIM2 :
 
+            map_trucks_data(simdata, simmap);
 
             break;
     }


### PR DESCRIPTION
Restored mapping initialization which got lost after 6a3fcdb1c207b64fac707043b87cbd194a2ca8c3