### PR TITLE
feat: add basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,122 @@
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "master", "setup-ci" ]
+    tags: [ "*" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-simapi:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15
+    - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a
+      with:
+        arguments: ".#simapi"
+
+    - name: Set build dir
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        github_sha_hash=${{ github.sha }}
+        echo "github-sha-short=${github_sha_hash:0:7}" >> $GITHUB_OUTPUT
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=g++
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_BUILD_TYPE=Release
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: simapi-build
+        path: ${{ steps.strings.outputs.build-output-dir }}
+
+    - name: Prepare release
+      run: |
+        mkdir simapi_release
+        cp -r \
+          include \
+          build/libsimapi.so \
+          build/libsimapi.so.1 \
+          build/libsimapi.so.1.0.1 \
+          build/simapi.pc \
+          simapi_release/
+
+        cd simapi_release
+        tar -czvf simapi.tar.gz ./*
+    
+    - name: Set tarball name
+      if: github.ref_type == 'tag'
+      run: |
+        cd simapi_release
+        mv simapi.tar.gz simapi-${{ github.ref_name }}.tar.gz
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: github.ref_type == 'tag'
+      with:
+        name: SimAPI ${{ github.ref_name }}
+        fail_on_unmatched_files: true
+        files: |
+          simapi_release/simapi-${{ github.ref_name }}.tar.gz
+
+  build-simd:
+    runs-on: ubuntu-latest
+    needs: build-simapi
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15
+    - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a
+      with:
+        arguments: ".#simd"
+
+    - name: Download Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: simapi-build
+
+    - name: Set build dir
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/simd/build" >> "$GITHUB_OUTPUT"
+        github_sha_hash=${{ github.sha }}
+        echo "github-sha-short=${github_sha_hash:0:7}" >> $GITHUB_OUTPUT
+    
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=g++
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_BUILD_TYPE=Release
+        -S ${{ github.workspace }}/simd
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: github.ref_type == 'tag'
+      with:
+        name: Simd ${{ github.ref_name }}
+        fail_on_unmatched_files: true
+        files: |
+          simd/build/simd

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766070988,
+        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    self.submodules = true;
+  };
+
+  outputs = { nixpkgs, ... }:
+  let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+    simapi = pkgs.stdenv.mkDerivation {
+      name = "simapi";
+      version = "0.1.0";
+
+      src = ./.;
+
+      buildInputs = [
+        pkgs.cmake
+      ];
+    };
+
+    simd = pkgs.stdenv.mkDerivation {
+      name = "simd";
+      version = "0.1.0";
+
+      src = ./.;
+
+      preConfigure = ''
+        cd simd
+      '';
+
+      buildInputs = [
+        simapi
+
+        pkgs.cmake
+        pkgs.libuv
+        pkgs.yder
+        pkgs.libconfig
+        pkgs.argtable
+      ];
+
+      installPhase = ''
+        install -D -m 755 -v ./simd $out/bin/simd
+      '';
+    };
+  in
+  {
+    packages.x86_64-linux = {
+      default = simapi;
+      inherit simapi simd;
+    };
+
+    devShells.x86_64-linux.default = pkgs.mkShell {
+      packages = simapi.buildInputs ++ simd.buildInputs ++ [
+        simapi
+      ];
+    };
+  };
+}

--- a/simapi.pc.in
+++ b/simapi.pc.in
@@ -1,7 +1,8 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=${prefix}
+
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed -ldl")
 #set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(simd simd.c parameters.c confighelper.c dirhelper.c poke.c ../simmap/mapsimdata.c)
-target_link_libraries(simd m uv yder argtable2 config simapi)
+target_link_libraries(simd m uv yder argtable3 config simapi)
 
 target_include_directories(simd PUBLIC)
 

--- a/simd/parameters.c
+++ b/simd/parameters.c
@@ -6,7 +6,7 @@
 
 #include <libconfig.h>
 
-#include <argtable2.h>
+#include <argtable3.h>
 #include <regex.h>
 
 

--- a/simd/simd.c
+++ b/simd/simd.c
@@ -659,7 +659,7 @@ int main(int argc, char** argv)
     }
 
 
-    int pid_file_fd = open(PID_FILE, O_WRONLY | O_CREAT | O_EXCL);
+    int pid_file_fd = open(PID_FILE, O_WRONLY | O_CREAT | O_EXCL, 0666);
     if(pid_file_fd == -1)
     {
         if( simds.poke == true )


### PR DESCRIPTION
* CI will build simapi and simd on all commits and PRs to master branch.
* Tags will be automatically published to the releases page.
* Nix packages also defined for simapi and simd.
* Nix devshell defined for local development, just run `nix develop .` from anywhere in the repo to enter a shell with all tooling and dependencies paths setup.
* Upgrade argtable2 -> argtable3.

To install Nix, the Determinate Systems Nix Installer is recommended as it has some defaults which may be preferable for people completely new to Nix:
```shell
curl -fsSL https://install.determinate.systems/nix | sh -s -- install
```