### PR TITLE
Calculate suspension velocity for ac

### DIFF
--- a/simapi/ac.h
+++ b/simapi/ac.h
@@ -2,6 +2,7 @@
 #define _AC_H
 
 #include <stdbool.h>
+#include <time.h>
 #include "../include/acdata.h"
 
 #define AC_EXE "acs.exe"
@@ -36,6 +37,8 @@ typedef struct
     char driver[32];
     char track[32];
     char compound[32];
+    float prev_suspension[4];
+    struct timespec prev_time;
 }
 ACMap;
 

--- a/simapi/ac.h
+++ b/simapi/ac.h
@@ -2,7 +2,6 @@
 #define _AC_H
 
 #include <stdbool.h>
-#include <time.h>
 #include "../include/acdata.h"
 
 #define AC_EXE "acs.exe"
@@ -37,8 +36,6 @@ typedef struct
     char driver[32];
     char track[32];
     char compound[32];
-    float prev_suspension[4];
-    struct timespec prev_time;
 }
 ACMap;
 

--- a/simapi/mapping/acmapper.c
+++ b/simapi/mapping/acmapper.c
@@ -9,8 +9,6 @@
 
 #include "../../include/acdata.h"
 
-#define NANOS_PER_SEC 1e9
-
 static LapTime ac_convert_to_simdata_laptime(int ac_laptime)
 {
     LapTime l;
@@ -136,26 +134,21 @@ void map_assetto_corsa_data(SimData* simdata, SimMap* simmap, SimulatorEXE simex
     simdata->worldZvelocity = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, velocity) + (sizeof(float) * 1 ));
     simdata->worldYvelocity = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, velocity) + (sizeof(float) * 2 ));
 
-    simdata->suspension[0] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 0));
-    simdata->suspension[1] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 1));
-    simdata->suspension[2] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 2));
-    simdata->suspension[3] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 3));
-    // Calculate suspension velocity as rate of change between frames
-    {
-        struct timespec curr_time;
-        clock_gettime(CLOCK_MONOTONIC, &curr_time);
-        double dt = (curr_time.tv_sec - simmap->ac.prev_time.tv_sec) +
-                    (curr_time.tv_nsec - simmap->ac.prev_time.tv_nsec) / NANOS_PER_SEC;
-        if (dt > 0 && (simmap->ac.prev_time.tv_sec != 0 || simmap->ac.prev_time.tv_nsec != 0)) {
-            for (int i = 0; i < 4; i++) {
-                simdata->suspvelocity[i] = (double)fabs((simdata->suspension[i] - simmap->ac.prev_suspension[i]) / dt);
-            }
-        }
-        for (int i = 0; i < 4; i++) {
-            simmap->ac.prev_suspension[i] = simdata->suspension[i];
-        }
-        simmap->ac.prev_time = curr_time;
-    }
+    // Read new suspension values
+    double new_suspension[4];
+    new_suspension[0] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 0));
+    new_suspension[1] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 1));
+    new_suspension[2] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 2));
+    new_suspension[3] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 3));
+    
+    // Calculate suspension velocity using the common function (uses previous suspension values from simdata)
+    map_suspension_velocity(simdata, new_suspension);
+    
+    // Now update suspension with new values
+    simdata->suspension[0] = new_suspension[0];
+    simdata->suspension[1] = new_suspension[1];
+    simdata->suspension[2] = new_suspension[2];
+    simdata->suspension[3] = new_suspension[3];
 
 
     //advanced ui

--- a/simapi/mapping/acmapper.c
+++ b/simapi/mapping/acmapper.c
@@ -9,6 +9,8 @@
 
 #include "../../include/acdata.h"
 
+#define NANOS_PER_SEC 1e9
+
 static LapTime ac_convert_to_simdata_laptime(int ac_laptime)
 {
     LapTime l;
@@ -138,6 +140,22 @@ void map_assetto_corsa_data(SimData* simdata, SimMap* simmap, SimulatorEXE simex
     simdata->suspension[1] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 1));
     simdata->suspension[2] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 2));
     simdata->suspension[3] = *(float*) (char*) (a + offsetof(struct SPageFilePhysics, suspensionTravel) + (sizeof(float) * 3));
+    // Calculate suspension velocity as rate of change between frames
+    {
+        struct timespec curr_time;
+        clock_gettime(CLOCK_MONOTONIC, &curr_time);
+        double dt = (curr_time.tv_sec - simmap->ac.prev_time.tv_sec) +
+                    (curr_time.tv_nsec - simmap->ac.prev_time.tv_nsec) / NANOS_PER_SEC;
+        if (dt > 0 && (simmap->ac.prev_time.tv_sec != 0 || simmap->ac.prev_time.tv_nsec != 0)) {
+            for (int i = 0; i < 4; i++) {
+                simdata->suspvelocity[i] = (double)fabs((simdata->suspension[i] - simmap->ac.prev_suspension[i]) / dt);
+            }
+        }
+        for (int i = 0; i < 4; i++) {
+            simmap->ac.prev_suspension[i] = simdata->suspension[i];
+        }
+        simmap->ac.prev_time = curr_time;
+    }
 
 
     //advanced ui

--- a/simapi/simdata.h
+++ b/simapi/simdata.h
@@ -90,6 +90,7 @@ typedef struct //ProximityData
 typedef struct //SimData
 {
     uint64_t mtick;
+    uint64_t prev_mtick;
 
     uint32_t simstatus; // less than 1 is off or in menu, 2 is active
     uint32_t velocity;

--- a/simapi/simmapper.c
+++ b/simapi/simmapper.c
@@ -80,6 +80,24 @@ long long timeInMilliseconds(void)
     return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
 }
 
+void map_suspension_velocity(SimData* simdata, double new_suspension[4])
+{
+    // Calculate suspension velocity as rate of change between frames
+    // Units: meters per second (m/s)
+    // Note: simdata->suspension contains previous frame's values at this point
+    if (simdata->prev_mtick > 0 && simdata->mtick > simdata->prev_mtick)
+    {
+        double dt = (double)(simdata->mtick - simdata->prev_mtick) / 1000.0; // Convert ms to seconds
+        if (dt > 0)
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                simdata->suspvelocity[i] = fabs((new_suspension[i] - simdata->suspension[i]) / dt);
+            }
+        }
+    }
+}
+
 bool simapi_does_sim_need_bridge(SimulatorEXE s)
 {
     if(s == SIMULATOREXE_ASSETTO_CORSA || s == SIMULATOREXE_ASSETTO_CORSA_COMPETIZIONE || s == SIMULATOREXE_ASSETTO_CORSA_EVO || s == SIMULATOREXE_ASSETTO_CORSA_RALLY)
@@ -1156,6 +1174,7 @@ int simapi_datamap(SimData* simdata, SimMap* simmap, SimulatorAPI simulatorapi, 
     char* c;
     char* d;
 
+    simdata->prev_mtick = simdata->mtick;
     simdata->mtick = timeInMilliseconds();
 
     switch ( simulatorapi )

--- a/simapi/simmapper.h
+++ b/simapi/simmapper.h
@@ -67,6 +67,8 @@ int simapi_compatmap_clear(SimCompatMap* compatmap);
 
 void simapi_set_proximity_data(SimData* simdata, int cars, int8_t lr_flip);
 
+void map_suspension_velocity(SimData* simdata, double new_suspension[4]);
+
 void map_assetto_corsa_data(SimData* simdata, SimMap* simmap, SimulatorEXE simexe);
 void map_rfactor2_data(SimData* simdata, SimMap* simmap);
 void map_project_cars2_data(SimData* simdata, SimMap* simmap, bool udp, char* base);


### PR DESCRIPTION
It appears that AC doesn't provide suspension velocity data, so this is a small change to the ac mapper to derive it from the suspension values vs time.

The reason why I went to add this is I found that in AC I couldn't get a good effect to give me a decent impact effect hitting ripple strips. In the cars I tested with, the suspension travel wasn't much different driving on the road vs driving off the track so the suspension's velocity is a good way to catch that.

Corresponding changes that plumb through the suspension velocity will be raised in the monocoque repo.