### PR TITLE
feat(docs): Add Moza KS Pro Wheel documentation

### DIFF
--- a/docs/mozakspro.md
+++ b/docs/mozakspro.md
@@ -1,0 +1,26 @@
+# Moza KS Pro Wheel
+
+The Moza KS Pro Wheel will track RPMs with its LEDs and display flag signals.
+
+- 12 RPM shift-light LEDs illuminate progressively from 75% to 97% of max RPM
+- LEDs blink at 98%+ RPM
+- Yellow flag signal illuminates the flag LEDs amber
+
+Use this config (or add relevant block to an existing config):
+
+```
+configs =
+({
+   sim = "default";
+   car = "default";
+   devices = ( {
+                    device       = "Serial";
+                    type         = "Wheel";
+                    subtype      = "MozaKSProWheel";
+                    devpath      = "/dev/ttyACM0";
+                    baud         = 115200;
+                }
+            );
+});
+
+```

--- a/docs/thirdpartydevices.md
+++ b/docs/thirdpartydevices.md
@@ -6,6 +6,8 @@ Clubsport Elite V3 Pedals
 
 [Moza R5](https://spacefreak18.github.io/simapi/mozar5)
 
+[Moza KS Pro Wheel](https://spacefreak18.github.io/simapi/mozakspro)
+
 Cammus C5
 
 Cammus C12


### PR DESCRIPTION
This is the documentation for the Moza R12 + KS Pro Wheel combination. 

Related to: https://github.com/Spacefreak18/monocoque/pull/42