### PR TITLE
fix: two build portability issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,13 @@ pkg_check_modules(LIBPROC2 libproc2)
 if (LIBPROCPS_FOUND)
     #add_compile_definitions(USE_OLD_PID_VAL=0)
 elseif (LIBPROC2_FOUND)
-    if (LIBPROC2_VERSION VERSION_GREATER_EQUAL "4.0.5")
-        #add_compile_definitions(USE_OLD_PID_VAL=0)
-    else()
+    # Some distro packagings -- the freedesktop Flatpak SDK among them -- ship
+    # a libproc2.pc whose Version field is the literal string UNKNOWN. Compared
+    # against that, VERSION_GREATER_EQUAL is always false, so this fell through
+    # to the pre-4.0.5 four-argument PIDS_VAL API and failed to compile against
+    # a current libproc2 whose header has long since moved to three. Take the
+    # old-API branch only when the version really parses and really is old.
+    if (LIBPROC2_VERSION MATCHES "^[0-9]" AND LIBPROC2_VERSION VERSION_LESS "4.0.5")
         add_compile_definitions(USE_OLD_PID_VAL)
     endif()
 else()

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -32,6 +32,19 @@ endif()
 add_executable(simd simd.c parameters.c confighelper.c dirhelper.c poke.c ../simmap/mapsimdata.c)
 target_link_libraries(simd m uv yder ${ARGTABLE_LIBS} config simapi)
 
+# yder calls into orcania -- o_malloc, o_free, o_strdup, o_strnullempty,
+# split_string. A shared libyder.so records that dependency and the linker
+# follows it, which is why this is not needed on Debian or Ubuntu. A static
+# libyder.a records nothing, so all of those come back undefined unless
+# orcania is named explicitly, and after yder, which is the order a static
+# link needs. Distributions without a yder package -- Fedora among them --
+# have to vendor it, and vendoring it static is what keeps the resulting
+# package free of a dependency those distributions cannot satisfy.
+find_library(ORCANIA_LIBRARY orcania)
+if(ORCANIA_LIBRARY)
+    target_link_libraries(simd ${ORCANIA_LIBRARY})
+endif()
+
 target_include_directories(simd PRIVATE ${ARGTABLE_INCLUDE_DIR})
 
 # User-level installation


### PR DESCRIPTION
Two small independent CMake fixes, found while building simd across several distributions. No behaviour change on a system where it already builds.

### `libproc2.pc` reporting `Version: UNKNOWN`

Some distro packagings ship a `libproc2.pc` whose Version field is the literal string `UNKNOWN` — the freedesktop Flatpak SDK among them. Compared against that, `VERSION_GREATER_EQUAL` is always false, so the build falls through to the pre-4.0.5 four-argument `PIDS_VAL` API and fails to compile against a current libproc2 whose header moved to three arguments long ago.

Now takes the old-API branch only when the version string really parses and really is old.

### orcania not named when yder is static

simd links yder, and yder calls into orcania: `o_malloc`, `o_free`, `o_strdup`, `o_strnullempty`, `split_string`. A shared `libyder.so` records that dependency and the linker follows it, which is why nothing is needed on Debian or Ubuntu where `libyder-dev` exists.

A static `libyder.a` records nothing, so all of those come back undefined. Fedora packages neither yder nor orcania — `dnf install yder-devel` fails outright on 43 and 44 — so building simd there means vendoring both, and vendoring them static is what keeps the result free of a dependency Fedora cannot satisfy. The link then fails with a wall of undefined references attributed to `libyder.so`.

Guarded on `find_library`, so it is a no-op where orcania isn't a separate library.

---

Both verified building against current master. These are split out from packaging work so they can be judged on their own — happy to fold them in elsewhere if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)