### PR TITLE
refactor: one definition of is_pid_running

### DIFF
--- a/simapi/getpid.c
+++ b/simapi/getpid.c
@@ -39,14 +39,18 @@ static int isMatch(const char* possibleMatch, const char* checkAgainst)
 
 int is_pid_running(pid_t pid)
 {
-    if (simapi_in_flatpak())
-    {
-        return simapi_host_pid_alive(pid);
-    }
-
     if (pid <= 0)
     {
         return 0;
+    }
+
+    /* Sandboxed, the pids being tracked belong to the host's namespace, where
+     * kill(2) cannot reach them. This is the single definition: simd calls it
+     * through simapi.h rather than carrying its own copy, so both halves ask
+     * the question the same way and a change here reaches both. */
+    if (simapi_in_flatpak())
+    {
+        return simapi_host_pid_alive(pid);
     }
 
     // send signal 0 (no actual signal)

--- a/simd/simd.c
+++ b/simd/simd.c
@@ -365,45 +365,6 @@ static bool bridge_file_exists(const char* path)
     return does_file_exist(path);
 }
 
-int is_pid_running(pid_t pid)
-{
-    if (pid <= 0)
-    {
-        return 0;
-    }
-
-    /* Sandboxed, the pids simd tracks belong to the host's namespace, where
-     * kill(2) cannot reach them. Shared with simapi so both halves agree on
-     * how the question is asked. */
-    if (simapi_in_flatpak())
-    {
-        return simapi_host_pid_alive(pid);
-    }
-
-    // send signal 0 (no actual signal)
-    if (kill(pid, 0) == 0)
-    {
-        return 1;
-    }
-    else
-    {
-        if (errno == ESRCH)
-        {
-            return 0;
-        }
-        else
-            if (errno == EPERM)
-            {
-                return 1;
-            }
-            else
-            {
-                return 0;
-            }
-        return 0;
-    }
-}
-
 void bridgeclosecallback(uv_timer_t* handle)
 {
     void* b = uv_handle_get_data((uv_handle_t*) handle);


### PR DESCRIPTION
Responding to your maintainability point on #35 — you were right, and this is the sharpest instance of it.

`is_pid_running` existed twice: once in `simapi/getpid.c` and once in `simd/simd.c`. Both were the same function. The duplicate resolved only because an executable's own definition wins over the shared library's, even though simd links simapi and includes `simapi.h` where it is declared.

Two identical copies were survivable. They stopped being so when the function grew a second code path — sandboxed, the pids being tracked belong to the host's namespace where `kill(2)` cannot reach them, so the lookup routes through the host. That made it a function with two implementations *and* two locations: a fix had to be applied twice, and nothing would tell you if you only changed one.

simd's copy is removed. The call resolves to the library's, confirmed by the symbols:

```
libsimapi.so:  T is_pid_running    (defined)
simd:          U is_pid_running    (undefined, resolved from the library)
```

The surviving copy also takes simd's better ordering — reject a bogus pid before asking the host anything.

Builds and runs clean. This removes one of the two places the sandbox branching had to be maintained; the remaining seams are all single dispatch points rather than duplicated logic.

I'd also suggest testing the sandboxed path in CI, since nothing currently exercises it — the Flatpak job installs and runs the bundle, so asserting simd sees the host's process table rather than the sandbox's four would turn a silent rot into a build failure. Happy to add that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)